### PR TITLE
Feat: track pool event

### DIFF
--- a/contracts/UniversalRouter.sol
+++ b/contracts/UniversalRouter.sol
@@ -18,8 +18,10 @@ contract UniversalRouter is IUniversalRouter, Transfers, Ownable2Step {
     using Path2 for bytes;
     using BytesLib2 for bytes;
 
-    /// @dev Returns protocol route contracts by their protocolId
+    /// @inheritdoc IUniversalRouter
     mapping(uint16 => address) public override protocolRoutes;
+
+    /// @inheritdoc IUniversalRouter
     mapping(address => bool) public override trackedPairs;
 
     /// @dev Initialize `WETH` address to Wrapped Ethereum contract
@@ -31,23 +33,6 @@ contract UniversalRouter is IUniversalRouter, Transfers, Ownable2Step {
     modifier ensure(uint256 deadline) {
         require(deadline >= block.timestamp, 'UniversalRouter: EXPIRED');
         _;
-    }
-
-    /// @inheritdoc IUniversalRouter
-    function trackPair(address token0, address token1, uint24 fee, uint16 protocolId) external virtual override onlyOwner {
-        require(token0 != address(0), 'UniversalRouter: ZERO_ADDRESS');
-        require(token1 != address(0), 'UniversalRouter: ZERO_ADDRESS');
-
-        address protocol = protocolRoutes[protocolId];
-        require(protocol != address(0), 'UniversalRouter: ROUTE_NOT_SET_UP');
-
-        address pair;
-        (pair, token0, token1) = IProtocolRoute(protocol).pairFor(token0, token1, fee);
-
-        require(trackedPairs[pair] == false, "UniversalRouter: ALREADY_TRACKED");
-        trackedPairs[pair] = true;
-
-        emit TrackPair(pair, token0, token1, fee);
     }
 
     /// @inheritdoc IUniversalRouter
@@ -251,6 +236,23 @@ contract UniversalRouter is IUniversalRouter, Transfers, Ownable2Step {
                 --i;
             }
         }
+    }
+
+    /// @inheritdoc IUniversalRouter
+    function trackPair(address token0, address token1, uint24 fee, uint16 protocolId) external virtual override onlyOwner {
+        require(token0 != address(0), 'UniversalRouter: ZERO_ADDRESS');
+        require(token1 != address(0), 'UniversalRouter: ZERO_ADDRESS');
+
+        address protocol = protocolRoutes[protocolId];
+        require(protocol != address(0), 'UniversalRouter: ROUTE_NOT_SET_UP');
+
+        address pair;
+        (pair, token0, token1) = IProtocolRoute(protocol).pairFor(token0, token1, fee);
+
+        require(trackedPairs[pair] == false, "UniversalRouter: ALREADY_TRACKED");
+        trackedPairs[pair] = true;
+
+        emit TrackPair(pair, token0, token1, fee);
     }
 
     /// @inheritdoc Transfers

--- a/contracts/UniversalRouter.sol
+++ b/contracts/UniversalRouter.sol
@@ -252,7 +252,9 @@ contract UniversalRouter is IUniversalRouter, Transfers, Ownable2Step {
         require(trackedPairs[pair] == false, "UniversalRouter: ALREADY_TRACKED");
         trackedPairs[pair] = true;
 
-        emit TrackPair(pair, token0, token1, fee);
+        address factory = IProtocolRoute(protocol).factory();
+
+        emit TrackPair(pair, token0, token1, fee, factory);
     }
 
     /// @inheritdoc Transfers

--- a/contracts/interfaces/IProtocolRoute.sol
+++ b/contracts/interfaces/IProtocolRoute.sol
@@ -11,6 +11,15 @@ interface IProtocolRoute {
     /// @return id of protocol route
     function protocolId() external view returns(uint16);
 
+    /// @dev Get AMM for tokenA and tokenB pair.
+    /// @param tokenA - address of a token of the AMM pool
+    /// @param tokenB - address of other token of the AMM pool
+    /// @param fee - AMM fee used to identify AMM pool
+    /// @return pair - address of AMM for token pair
+    /// @return token0 - address of token0 in AMM
+    /// @return token1 - address of token1 in AMM
+    function pairFor(address tokenA, address tokenB, uint24 fee) external view returns (address pair, address token0, address token1);
+
     /// @dev Get conversion amount of amountIn of tokenIn in tokenOut. Conversion happens at marginal price of AMM
     /// @param amountIn - quantity of tokenIn token to convert to tokenOut
     /// @param tokenIn - address token of amountIn quantity that will be converted

--- a/contracts/interfaces/IProtocolRoute.sol
+++ b/contracts/interfaces/IProtocolRoute.sol
@@ -11,6 +11,9 @@ interface IProtocolRoute {
     /// @return id of protocol route
     function protocolId() external view returns(uint16);
 
+    /// @return factory contract of AMMs for this route
+    function factory() external view returns(address);
+
     /// @dev Get AMM for tokenA and tokenB pair.
     /// @param tokenA - address of a token of the AMM pool
     /// @param tokenB - address of other token of the AMM pool

--- a/contracts/interfaces/IUniversalRouter.sol
+++ b/contracts/interfaces/IUniversalRouter.sol
@@ -96,7 +96,7 @@ interface IUniversalRouter {
     /// @return routes - array of route parameters to perform swap through the path provided
     function getAmountsIn(uint256 amountOut, bytes memory path) external returns (uint256[] memory amounts, Route[] memory routes);
 
-    /// @dev Check if already emitted event to track pair
+    /// @dev Check if already emitted TrackPair event for pair
     /// @param pair - address of AMM tracked
     function trackedPairs(address pair) external view returns(bool);
 

--- a/contracts/interfaces/IUniversalRouter.sol
+++ b/contracts/interfaces/IUniversalRouter.sol
@@ -11,7 +11,7 @@ interface IUniversalRouter {
     /// @dev emitted when a protocol route is removed
     event RemoveProtocolRoute(uint16 indexed protocolId, address protocol);
     /// @dev emitted when a pair is tracked
-    event TrackPair(address indexed pair, address token0, address token1, uint24 fee);
+    event TrackPair(address indexed pair, address token0, address token1, uint24 fee, address factory);
 
     /// @dev Route struct that contains instructions to perform a swap through supported routes
     struct Route {

--- a/contracts/interfaces/IUniversalRouter.sol
+++ b/contracts/interfaces/IUniversalRouter.sol
@@ -10,6 +10,8 @@ interface IUniversalRouter {
     event AddProtocolRoute(uint16 indexed protocolId, address protocol);
     /// @dev emitted when a protocol route is removed
     event RemoveProtocolRoute(uint16 indexed protocolId, address protocol);
+    /// @dev emitted when a pair is tracked
+    event TrackPair(address indexed pair, address token0, address token1, uint24 fee);
 
     /// @dev Route struct that contains instructions to perform a swap through supported routes
     struct Route {
@@ -93,4 +95,15 @@ interface IUniversalRouter {
     /// @return amounts - amounts of tokens swapped through the path provided
     /// @return routes - array of route parameters to perform swap through the path provided
     function getAmountsIn(uint256 amountOut, bytes memory path) external returns (uint256[] memory amounts, Route[] memory routes);
+
+    /// @dev Check if already emitted event to track pair
+    /// @param pair - address of AMM tracked
+    function trackedPairs(address pair) external view returns(bool);
+
+    /// @dev Emit event detailing AMM for tokenA and tokenB pair so that it's tracked in subgraph.
+    /// @param token0 - address of a token of the AMM pool
+    /// @param token1 - address of other token of the AMM pool
+    /// @param fee - AMM fee used to identify AMM pool
+    /// @param protocolId - protocolId identifying route pair belongs to
+    function trackPair(address token0, address token1, uint24 fee, uint16 protocolId) external;
 }

--- a/contracts/interfaces/external/IAeroCLPoolFactory.sol
+++ b/contracts/interfaces/external/IAeroCLPoolFactory.sol
@@ -5,12 +5,8 @@ import './aerodrome-cl/IAeroVoter.sol';
 import './aerodrome-cl/IAeroFactoryRegistry.sol';
 
 /// @title Interface for the Aerodrome Concentrated Liquidity Factory within UniversalRouter
-/// @author Daniel D. Alcarraz (https://github.com/0xDanr)
 /// @notice The Concentrated Liquidity Factory facilitates creation of CL pools and control over the protocol fees
-/// @dev This is a limited implementation for use in UniversalRouter
-/// @dev Write functions are defined only for unit testing
 interface IAeroCLPoolFactory {
-
     /// @notice Emitted when the owner of the factory is changed
     /// @param oldOwner The owner before the owner was changed
     /// @param newOwner The owner after the owner was changed

--- a/contracts/interfaces/external/IAeroPool.sol
+++ b/contracts/interfaces/external/IAeroPool.sol
@@ -1,10 +1,20 @@
-// SPDX-License-Identifier: GPL-2.0-or-later
+// SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
 
-/// @title Interface for the Aerodrome Pool within UniversalRouter
-/// @author Daniel D. Alcarraz (https://github.com/0xDanr)
-/// @dev This is a limited implementation for use in UniversalRouter. Sufficient to perform swaps
+/// @title Interface for the Aerodrome Pool
 interface IAeroPool {
+    error DepositsNotEqual();
+    error BelowMinimumK();
+    error FactoryAlreadySet();
+    error InsufficientLiquidity();
+    error InsufficientLiquidityMinted();
+    error InsufficientLiquidityBurned();
+    error InsufficientOutputAmount();
+    error InsufficientInputAmount();
+    error IsPaused();
+    error InvalidTo();
+    error K();
+    error NotEmergencyCouncil();
 
     event Fees(address indexed sender, uint256 amount0, uint256 amount1);
     event Mint(address indexed sender, uint256 amount0, uint256 amount1);
@@ -20,12 +30,155 @@ interface IAeroPool {
     event Sync(uint256 reserve0, uint256 reserve1);
     event Claim(address indexed sender, address indexed recipient, uint256 amount0, uint256 amount1);
 
-    /// @notice Read reserve token quantities in the AMM, and timestamp of last update
-    /// @dev Reserve quantities come back as uint112 although we store them as uint128
-    /// @return reserve0 - quantity of token0 held in AMM
-    /// @return reserve1 - quantity of token1 held in AMM
-    /// @return blockTimestampLast - timestamp of the last update block
-    function getReserves() external view returns (uint256 reserve0, uint256 reserve1, uint256 blockTimestampLast);
+    // Struct to capture time period obervations every 30 minutes, used for local oracles
+    struct Observation {
+        uint256 timestamp;
+        uint256 reserve0Cumulative;
+        uint256 reserve1Cumulative;
+    }
+
+    /// @notice Returns the decimal (dec), reserves (r), stable (st), and tokens (t) of token0 and token1
+    function metadata()
+    external
+    view
+    returns (uint256 dec0, uint256 dec1, uint256 r0, uint256 r1, bool st, address t0, address t1);
+
+    /// @notice Claim accumulated but unclaimed fees (claimable0 and claimable1)
+    function claimFees() external returns (uint256, uint256);
+
+    /// @notice Returns [token0, token1]
+    function tokens() external view returns (address, address);
+
+    /// @notice Address of token in the pool with the lower address value
+    function token0() external view returns (address);
+
+    /// @notice Address of token in the poool with the higher address value
+    function token1() external view returns (address);
+
+    /// @notice Address of linked PoolFees.sol
+    function poolFees() external view returns (address);
+
+    /// @notice Address of PoolFactory that created this contract
+    function factory() external view returns (address);
+
+    /// @notice Capture oracle reading every 30 minutes (1800 seconds)
+    function periodSize() external view returns (uint256);
+
+    /// @notice Amount of token0 in pool
+    function reserve0() external view returns (uint256);
+
+    /// @notice Amount of token1 in pool
+    function reserve1() external view returns (uint256);
+
+    /// @notice Timestamp of last update to pool
+    function blockTimestampLast() external view returns (uint256);
+
+    /// @notice Cumulative of reserve0 factoring in time elapsed
+    function reserve0CumulativeLast() external view returns (uint256);
+
+    /// @notice Cumulative of reserve1 factoring in time elapsed
+    function reserve1CumulativeLast() external view returns (uint256);
+
+    /// @notice Accumulated fees of token0 (global)
+    function index0() external view returns (uint256);
+
+    /// @notice Accumulated fees of token1 (global)
+    function index1() external view returns (uint256);
+
+    /// @notice Get an LP's relative index0 to index0
+    function supplyIndex0(address) external view returns (uint256);
+
+    /// @notice Get an LP's relative index1 to index1
+    function supplyIndex1(address) external view returns (uint256);
+
+    /// @notice Amount of unclaimed, but claimable tokens from fees of token0 for an LP
+    function claimable0(address) external view returns (uint256);
+
+    /// @notice Amount of unclaimed, but claimable tokens from fees of token1 for an LP
+    function claimable1(address) external view returns (uint256);
+
+    /// @notice Returns the value of K in the Pool, based on its reserves.
+    function getK() external returns (uint256);
+
+    /// @notice Set pool name
+    ///         Only callable by Voter.emergencyCouncil()
+    /// @param __name String of new name
+    function setName(string calldata __name) external;
+
+    /// @notice Set pool symbol
+    ///         Only callable by Voter.emergencyCouncil()
+    /// @param __symbol String of new symbol
+    function setSymbol(string calldata __symbol) external;
+
+    /// @notice Get the number of observations recorded
+    function observationLength() external view returns (uint256);
+
+    /// @notice Get the value of the most recent observation
+    function lastObservation() external view returns (Observation memory);
+
+    /// @notice True if pool is stable, false if volatile
+    function stable() external view returns (bool);
+
+    /// @notice Produces the cumulative price using counterfactuals to save gas and avoid a call to sync.
+    function currentCumulativePrices()
+    external
+    view
+    returns (uint256 reserve0Cumulative, uint256 reserve1Cumulative, uint256 blockTimestamp);
+
+    /// @notice Provides twap price with user configured granularity, up to the full window size
+    /// @param tokenIn .
+    /// @param amountIn .
+    /// @param granularity .
+    /// @return amountOut .
+    function quote(address tokenIn, uint256 amountIn, uint256 granularity) external view returns (uint256 amountOut);
+
+    /// @notice Returns a memory set of TWAP prices
+    ///         Same as calling sample(tokenIn, amountIn, points, 1)
+    /// @param tokenIn .
+    /// @param amountIn .
+    /// @param points Number of points to return
+    /// @return Array of TWAP prices
+    function prices(address tokenIn, uint256 amountIn, uint256 points) external view returns (uint256[] memory);
+
+    /// @notice Same as prices with with an additional window argument.
+    ///         Window = 2 means 2 * 30min (or 1 hr) between observations
+    /// @param tokenIn .
+    /// @param amountIn .
+    /// @param points .
+    /// @param window .
+    /// @return Array of TWAP prices
+    function sample(
+        address tokenIn,
+        uint256 amountIn,
+        uint256 points,
+        uint256 window
+    ) external view returns (uint256[] memory);
+
+    /// @notice This low-level function should be called from a contract which performs important safety checks
+    /// @param amount0Out   Amount of token0 to send to `to`
+    /// @param amount1Out   Amount of token1 to send to `to`
+    /// @param to           Address to recieve the swapped output
+    /// @param data         Additional calldata for flashloans
+    function swap(uint256 amount0Out, uint256 amount1Out, address to, bytes calldata data) external;
+
+    /// @notice This low-level function should be called from a contract which performs important safety checks
+    ///         standard uniswap v2 implementation
+    /// @param to Address to receive token0 and token1 from burning the pool token
+    /// @return amount0 Amount of token0 returned
+    /// @return amount1 Amount of token1 returned
+    function burn(address to) external returns (uint256 amount0, uint256 amount1);
+
+    /// @notice This low-level function should be called by addLiquidity functions in Router.sol, which performs important safety checks
+    ///         standard uniswap v2 implementation
+    /// @param to           Address to receive the minted LP token
+    /// @return liquidity   Amount of LP token minted
+    function mint(address to) external returns (uint256 liquidity);
+
+    /// @notice Update reserves and, on the first call per block, price accumulators
+    /// @return _reserve0 .
+    /// @return _reserve1 .
+    /// @return _blockTimestampLast .
+    function getReserves() external view returns (uint256 _reserve0, uint256 _reserve1, uint256 _blockTimestampLast);
 
     /// @notice Get the amount of tokenOut given the amount of tokenIn
     /// @param amountIn Amount of token in
@@ -33,11 +186,16 @@ interface IAeroPool {
     /// @return Amount out
     function getAmountOut(uint256 amountIn, address tokenIn) external view returns (uint256);
 
-    /// @notice Exchange one token for another token, must send token amount to exchange first before calling this function
-    /// @dev The user specifies which token amount to get. Therefore only one token amount parameter is greater than zero
-    /// @param amount0Out - address that will receive reserve tokens
-    /// @param amount1Out - address that will receive reserve tokens
-    /// @param to - address that will receive output token quantity
-    /// @param data - used for flash loan trades
-    function swap(uint256 amount0Out, uint256 amount1Out, address to, bytes calldata data) external;
+    /// @notice Force balances to match reserves
+    /// @param to Address to receive any skimmed rewards
+    function skim(address to) external;
+
+    /// @notice Force reserves to match balances
+    function sync() external;
+
+    /// @notice Called on pool creation by PoolFactory
+    /// @param _token0 Address of token0
+    /// @param _token1 Address of token1
+    /// @param _stable True if stable, false if volatile
+    function initialize(address _token0, address _token1, bool _stable) external;
 }

--- a/contracts/interfaces/external/IAeroPoolFactory.sol
+++ b/contracts/interfaces/external/IAeroPoolFactory.sol
@@ -1,13 +1,8 @@
-// SPDX-License-Identifier: GPL-2.0-or-later
+// SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
 
-/// @title Interface for the Aerodrome Pool Factory within UniversalRouter
-/// @author Daniel D. Alcarraz (https://github.com/0xDanr)
-/// @notice The AMM Factory facilitates creation of Aerodrome pools
-/// @dev This is a limited implementation for use in UniversalRouter
-/// @dev Write functions are defined only for unit testing
+/// @title Interface for the Aerodrome Pool Factory
 interface IAeroPoolFactory {
-
     event SetFeeManager(address feeManager);
     event SetPauser(address pauser);
     event SetPauseState(bool state);
@@ -15,11 +10,23 @@ interface IAeroPoolFactory {
     event PoolCreated(address indexed token0, address indexed token1, bool indexed stable, address pool, uint256);
     event SetCustomFee(address indexed pool, uint256 fee);
 
-    /// @notice Returns address of implementation Aerodrome pool contract from which all AMMs are made
-    function implementation() external view returns (address);
+    error FeeInvalid();
+    error FeeTooHigh();
+    error InvalidPool();
+    error NotFeeManager();
+    error NotPauser();
+    error NotVoter();
+    error PoolAlreadyExists();
+    error SameAddress();
+    error ZeroFee();
+    error ZeroAddress();
 
-    /// @notice Returns fee for a pool, as custom fees are possible.
-    function getFee(address _pool, bool _stable) external view returns (uint256);
+    /// @notice returns the number of pools created from this factory
+    function allPoolsLength() external view returns (uint256);
+
+    /// @notice Is a valid pool created by this factory.
+    /// @param .
+    function isPool(address pool) external view returns (bool);
 
     /// @notice Return address of pool created by this factory
     /// @param tokenA .
@@ -27,10 +34,57 @@ interface IAeroPoolFactory {
     /// @param stable True if stable, false if volatile
     function getPool(address tokenA, address tokenB, bool stable) external view returns (address);
 
+    /// @notice Support for v3-style pools which wraps around getPool(tokenA,tokenB,stable)
+    /// @dev fee is converted to stable boolean.
+    /// @param tokenA .
+    /// @param tokenB .
+    /// @param fee  1 if stable, 0 if volatile, else returns address(0)
+    function getPool(address tokenA, address tokenB, uint24 fee) external view returns (address);
+
+    /// @dev Only called once to set to Voter.sol - Voter does not have a function
+    ///      to call this contract method, so once set it's immutable.
+    ///      This also follows convention of setVoterAndDistributor() in VotingEscrow.sol
+    /// @param _voter .
+    function setVoter(address _voter) external;
+
+    function setPauser(address _pauser) external;
+
+    function setPauseState(bool _state) external;
+
+    function setFeeManager(address _feeManager) external;
+
+    /// @notice Set default fee for stable and volatile pools.
+    /// @dev Throws if higher than maximum fee.
+    ///      Throws if fee is zero.
+    /// @param _stable Stable or volatile pool.
+    /// @param _fee .
+    function setFee(bool _stable, uint256 _fee) external;
+
+    /// @notice Set overriding fee for a pool from the default
+    /// @dev A custom fee of zero means the default fee will be used.
+    function setCustomFee(address _pool, uint256 _fee) external;
+
+    /// @notice Returns fee for a pool, as custom fees are possible.
+    function getFee(address _pool, bool _stable) external view returns (uint256);
+
     /// @notice Create a pool given two tokens and if they're stable/volatile
     /// @dev token order does not matter
     /// @param tokenA .
     /// @param tokenB .
     /// @param stable .
     function createPool(address tokenA, address tokenB, bool stable) external returns (address pool);
+
+    /// @notice Support for v3-style pools which wraps around createPool(tokena,tokenB,stable)
+    /// @dev fee is converted to stable boolean
+    /// @dev token order does not matter
+    /// @param tokenA .
+    /// @param tokenB .
+    /// @param fee 1 if stable, 0 if volatile, else revert
+    function createPool(address tokenA, address tokenB, uint24 fee) external returns (address pool);
+
+    function isPaused() external view returns (bool);
+
+    function voter() external view returns (address);
+
+    function implementation() external view returns (address);
 }

--- a/contracts/routes/Aerodrome.sol
+++ b/contracts/routes/Aerodrome.sol
@@ -13,8 +13,6 @@ import './CPMMRoute.sol';
 /// @dev Implements IProtocolRoute functions to quote and handle one AMM swap at a time
 contract Aerodrome is CPMMRoute {
 
-    /// @dev address of Aerodrome factory contract
-    address public immutable factory;
     /// @dev address of Aerodrome pool used as implementation address by factory contract
     address public immutable implementation;
     /// @dev if set to true, it's for stable token pairs in Aerodrome

--- a/contracts/routes/Aerodrome.sol
+++ b/contracts/routes/Aerodrome.sol
@@ -34,14 +34,8 @@ contract Aerodrome is CPMMRoute {
         amountOut = _quote(amountIn, reserveIn, reserveOut);
     }
 
-    /// @dev Get AMM for tokenA and tokenB pair. Calculated using CREATE2 address for the pair without making any external calls
-    /// @dev Also return sorted token pair
-    /// @param tokenA - address of a token of the AMM pool
-    /// @param tokenB - address of other token of the AMM pool
-    /// @return pair - address of AMM for token pair
-    /// @return token0 - address of token in the AMM of lower value
-    /// @return token1 - address of token in the AMM of higher value
-    function pairFor(address tokenA, address tokenB) internal view returns (address pair, address token0, address token1) {
+    /// @inheritdoc IProtocolRoute
+    function pairFor(address tokenA, address tokenB, uint24 fee) public override virtual view returns (address pair, address token0, address token1) {
         (token0, token1) = _sortTokens(tokenA, tokenB);
         bytes32 salt = keccak256(abi.encodePacked(token0, token1, isStable));
         pair = Clones.predictDeterministicAddress(implementation, salt, factory);
@@ -56,7 +50,7 @@ contract Aerodrome is CPMMRoute {
     /// @return pair - address of AMM of tokenA and tokenB pair
     function getReserves(address tokenA, address tokenB) internal view returns (uint256 reserveA, uint256 reserveB, address pair) {
         address token0;
-        (pair, token0,) = pairFor(tokenA, tokenB);
+        (pair, token0,) = pairFor(tokenA, tokenB, 0);
         (uint256 reserve0, uint256 reserve1,) = IAeroPool(pair).getReserves();
         (reserveA, reserveB) = tokenA == token0 ? (reserve0, reserve1) : (reserve1, reserve0);
     }
@@ -64,7 +58,7 @@ contract Aerodrome is CPMMRoute {
     /// @inheritdoc IProtocolRoute
     function getAmountOut(uint256 amountIn, address tokenA, address tokenB, uint256 fee) public override virtual
         returns(uint256 amountOut, address pair, uint24 swapFee) {
-        (pair,,) = pairFor(tokenA, tokenB);
+        (pair,,) = pairFor(tokenA, tokenB, 0);
         swapFee = uint24(IAeroPoolFactory(factory).getFee(pair, isStable));
         amountOut = IAeroPool(pair).getAmountOut(amountIn, tokenA);
     }
@@ -84,13 +78,13 @@ contract Aerodrome is CPMMRoute {
     /// @inheritdoc IProtocolRoute
     function getOrigin(address tokenA, address tokenB, uint24 fee) external override virtual view
         returns(address pair, address origin) {
-        (pair,,) = pairFor(tokenA, tokenB);
+        (pair,,) = pairFor(tokenA, tokenB, fee);
         origin = pair;
     }
 
     /// @inheritdoc IProtocolRoute
     function swap(address from, address to, uint24 fee, address dest) external override virtual {
-        (address pair, address token0,) = pairFor(from, to);
+        (address pair, address token0,) = pairFor(from, to, fee);
         uint256 amountInput;
         uint256 amountOutput;
         { // scope to avoid stack too deep errors

--- a/contracts/routes/AerodromeCL.sol
+++ b/contracts/routes/AerodromeCL.sol
@@ -47,9 +47,6 @@ contract AerodromeCL is CPMMRoute, IUniswapV3SwapCallback {
         address recipient;
     }
 
-    /// @dev address of Aerodrome Concentrated Liquidity factory contract
-    address public immutable factory;
-
     /// @dev Transient storage variable used to check a safety condition in exact output swaps.
     uint256 private amountOutCached;
 

--- a/contracts/routes/AerodromeCL.sol
+++ b/contracts/routes/AerodromeCL.sol
@@ -40,7 +40,7 @@ contract AerodromeCL is CPMMRoute, IUniswapV3SwapCallback {
         /// @dev address of token swapped out
         address tokenOut;
         /// @dev tick spacing of AMM (used to identify AMM)
-        int24 tickSpacing;
+        uint24 tickSpacing;
         /// @dev amount of tokenIn swapped in
         uint256 amount;
         /// @dev address receiving output of swap in tokenOut
@@ -61,8 +61,7 @@ contract AerodromeCL is CPMMRoute, IUniswapV3SwapCallback {
 
     /// @inheritdoc IProtocolRoute
     function quote(uint256 amountIn, address tokenIn, address tokenOut, uint24 fee) public override virtual view returns (uint256 amountOut) {
-        address pair = pairFor(tokenIn, tokenOut, int24(fee));
-        (uint256 sqrtPriceX96,,,,,) = IAeroCLPool(pair).slot0();
+        (uint256 sqrtPriceX96,,,,,) = IAeroCLPool(_pairFor(tokenIn, tokenOut, fee)).slot0();
         if(tokenIn < tokenOut) {
             uint256 decimals = 10**GammaSwapLibrary.decimals(tokenIn);
             uint256 price = decodePrice(sqrtPriceX96, decimals);
@@ -86,20 +85,23 @@ contract AerodromeCL is CPMMRoute, IUniswapV3SwapCallback {
         price = sqrtPrice * sqrtPrice;
     }
 
-    /// @dev Get AMM for tokenA and tokenB pair. Calculated using CREATE2 address for the pair without making any external calls
-    /// @param tokenA - address of a token of the AMM pool
-    /// @param tokenB - address of other token of the AMM pool
-    /// @param tickSpacing - tickSpacing to calculate fees in Aerodrome CL pool
-    /// @return pair - address of AMM for token pair
-    function pairFor(address tokenA, address tokenB, int24 tickSpacing) internal view returns (address pair) {
-        pair = AeroPoolAddress.computeAddress(factory, AeroPoolAddress.getPoolKey(tokenA, tokenB, tickSpacing));
+    /// @inheritdoc IProtocolRoute
+    function pairFor(address tokenA, address tokenB, uint24 fee) public override virtual view returns (address pair, address token0, address token1) {
+        int24 tickSpacing = int24(fee);
+        (token0, token1) = tokenA < tokenB ? (tokenA, tokenB) : (tokenB, tokenA);
+        pair = AeroPoolAddress.computeAddress(factory, AeroPoolAddress.PoolKey({token0: token0, token1: token1, tickSpacing: tickSpacing}));
         require(GammaSwapLibrary.isContract(pair), 'AerodromeCL: AMM_DOES_NOT_EXIST');
+    }
+
+    /// @dev return only the pair address when calling pairFor
+    function _pairFor(address token0, address token1, uint24 fee) internal virtual view returns(address pair) {
+        (pair,,) = pairFor(token0, token1, fee);
     }
 
     /// @inheritdoc IProtocolRoute
     function getOrigin(address tokenA, address tokenB, uint24 fee) external override virtual view
         returns(address pair, address origin) {
-        pair = pairFor(tokenA, tokenB, int24(fee));
+        (pair,,) = pairFor(tokenA, tokenB, fee);
         origin = address(this);
     }
 
@@ -141,7 +143,7 @@ contract AerodromeCL is CPMMRoute, IUniswapV3SwapCallback {
     function getAmountOut(uint256 amountIn, address tokenIn, address tokenOut, uint256 fee) public override
         virtual returns(uint256 amountOut, address pair, uint24 swapFee) {
         swapFee = uint24(fee);
-        (amountOut, pair) = _quoteAmountOut(amountIn, tokenIn, tokenOut, int24(swapFee));
+        (amountOut, pair) = _quoteAmountOut(amountIn, tokenIn, tokenOut, swapFee);
     }
 
     /// @notice Calculate amountOut of tokenOut that will be received from swapping in amountIn in tokenIn
@@ -153,11 +155,11 @@ contract AerodromeCL is CPMMRoute, IUniswapV3SwapCallback {
     /// @param fee - fee charged by AMM, used to identify AMM in Aerodrome CL
     /// @return amountOut - amount of tokenOut that will be received from the swap
     /// @return pair - address of AMM contract in Aerodrome CL
-    function _quoteAmountOut(uint256 amountIn, address tokenIn, address tokenOut, int24 fee) internal virtual
+    function _quoteAmountOut(uint256 amountIn, address tokenIn, address tokenOut, uint24 fee) internal virtual
         returns(uint256 amountOut, address pair) {
 
         bool zeroForOne = tokenIn < tokenOut;
-        pair = pairFor(tokenIn, tokenOut, fee);
+        (pair,,) = pairFor(tokenIn, tokenOut, fee);
 
         try
             IAeroCLPool(pair).swap(
@@ -179,7 +181,7 @@ contract AerodromeCL is CPMMRoute, IUniswapV3SwapCallback {
     function getAmountIn(uint256 amountOut, address tokenIn, address tokenOut, uint256 fee) public
         override virtual returns(uint256 amountIn, address pair, uint24 swapFee) {
         swapFee = uint24(fee);
-        (amountIn, pair) = _quoteAmountIn(amountOut, tokenIn, tokenOut, int24(swapFee));
+        (amountIn, pair) = _quoteAmountIn(amountOut, tokenIn, tokenOut, swapFee);
     }
 
     /// @notice Calculate amountIn of tokenIn to swap for amountOut of tokenOut
@@ -191,9 +193,9 @@ contract AerodromeCL is CPMMRoute, IUniswapV3SwapCallback {
     /// @param fee - fee charged by AMM, used to identify AMM in Aerodrome CL
     /// @return amountIn - amount of tokenIn to swap in to get amountOut in tokenOut
     /// @return pair - address of AMM contract in Aerodrome CL
-    function _quoteAmountIn(uint256 amountOut, address tokenIn, address tokenOut, int24 fee) internal virtual
+    function _quoteAmountIn(uint256 amountOut, address tokenIn, address tokenOut, uint24 fee) internal virtual
         returns(uint256 amountIn, address pair) {
-        pair = pairFor(tokenIn, tokenOut, fee);
+        (pair,,) = pairFor(tokenIn, tokenOut, fee);
 
         // if no price limit has been specified, cache the output amount for comparison in the swap callback
         amountOutCached = amountOut;
@@ -222,7 +224,7 @@ contract AerodromeCL is CPMMRoute, IUniswapV3SwapCallback {
         exactInputSwap(SwapParams({
             tokenIn: from,
             tokenOut: to,
-            tickSpacing: int24(fee),
+            tickSpacing: fee,
             amount: inputAmount,
             recipient: dest
         }));
@@ -238,7 +240,7 @@ contract AerodromeCL is CPMMRoute, IUniswapV3SwapCallback {
         bool zeroForOne = params.tokenIn < params.tokenOut;
 
         (int256 amount0, int256 amount1) =
-            IAeroCLPool(pairFor(params.tokenIn, params.tokenOut, int24(params.tickSpacing))).swap(
+            IAeroCLPool(_pairFor(params.tokenIn, params.tokenOut, params.tickSpacing)).swap(
                 params.recipient,
                 zeroForOne,
                 int256(params.amount),
@@ -264,7 +266,7 @@ contract AerodromeCL is CPMMRoute, IUniswapV3SwapCallback {
         ? (tokenIn < tokenOut, uint256(amount0Delta), uint256(-amount1Delta))
         : (tokenOut < tokenIn, uint256(amount1Delta), uint256(-amount0Delta));
 
-        (uint160 sqrtPriceX96After, int24 tickAfter,,,,) = IAeroCLPool(pairFor(tokenIn, tokenOut, int24(fee))).slot0();
+        (uint160 sqrtPriceX96After, int24 tickAfter,,,,) = IAeroCLPool(_pairFor(tokenIn, tokenOut, fee)).slot0();
 
         if (isExactInput) {
             if(data.payer != address(0)) {

--- a/contracts/routes/CPMMRoute.sol
+++ b/contracts/routes/CPMMRoute.sol
@@ -12,6 +12,9 @@ abstract contract CPMMRoute is IProtocolRoute, Transfers {
     /// @inheritdoc IProtocolRoute
     uint16 public immutable override protocolId;
 
+    /// @inheritdoc IProtocolRoute
+    address public immutable override factory;
+
     /// @dev returns sorted token addresses, used to handle return values from pairs sorted in this order
     /// @param tokenA - address of first ERC20 token
     /// @param tokenB - address of second ERC20 token

--- a/contracts/routes/DeltaSwap.sol
+++ b/contracts/routes/DeltaSwap.sol
@@ -88,7 +88,7 @@ contract DeltaSwap is UniswapV2 {
 
     /// @inheritdoc IProtocolRoute
     function swap(address from, address to, uint24 fee, address dest) external override virtual {
-        (address pair, address token0,) = pairFor(from, to);
+        (address pair, address token0,) = pairFor(from, to, fee);
         uint256 amountInput;
         uint256 amountOutput;
         { // scope to avoid stack too deep errors

--- a/contracts/routes/UniswapV2.sol
+++ b/contracts/routes/UniswapV2.sol
@@ -10,9 +10,6 @@ import './CPMMRoute.sol';
 /// @dev Implements IProtocolRoute functions to quote and handle one AMM swap at a time
 contract UniswapV2 is CPMMRoute {
 
-    /// @dev address of UniswapV2 factory contract
-    address public immutable factory;
-
     /// @dev Initialize `_protocolId`, `_factory`, and `WETH` address
     constructor(uint16 _protocolId, address _factory, address _WETH) Transfers(_WETH) {
         protocolId = _protocolId;

--- a/contracts/routes/UniswapV3.sol
+++ b/contracts/routes/UniswapV3.sol
@@ -48,9 +48,6 @@ contract UniswapV3 is CPMMRoute, IUniswapV3SwapCallback {
     /// @dev init code hash used to calculate pool address from token pair, fee, and factory contract
     bytes32 internal constant POOL_INIT_CODE_HASH = 0xe34f199b19b2b4f47f68442619d555527d244f78a3297ea89325f843f87b8b54;
 
-    /// @dev address of UniswapV3 factory contract
-    address public immutable factory;
-
     /// @dev Transient storage variable used to check a safety condition in exact output swaps.
     uint256 private amountOutCached;
 

--- a/contracts/test/routes/TestAerodrome.sol
+++ b/contracts/test/routes/TestAerodrome.sol
@@ -11,7 +11,7 @@ contract TestAerodrome is Aerodrome {
 
     function getPairFor(address tokenA, address tokenB) public virtual view
         returns(address pair, address token0, address token1) {
-        return pairFor(tokenA, tokenB);
+        return pairFor(tokenA, tokenB, 0);
     }
 
     function getPairReserves(address tokenA, address tokenB) public virtual view

--- a/contracts/test/routes/TestAerodromeCL.sol
+++ b/contracts/test/routes/TestAerodromeCL.sol
@@ -11,7 +11,7 @@ contract TestAerodromeCL is AerodromeCL {
 
     function getPairFor(address tokenA, address tokenB, int24 tickSpacing) public virtual view
         returns(address pair) {
-        return pairFor(tokenA, tokenB, tickSpacing);
+        (pair,,) = pairFor(tokenA, tokenB, uint24(tickSpacing));
     }
 
     function getDecodedPrice(uint256 sqrtPriceX96, uint256 decimals) public virtual view

--- a/contracts/test/routes/TestDeltaSwap.sol
+++ b/contracts/test/routes/TestDeltaSwap.sol
@@ -14,7 +14,7 @@ contract TestDeltaSwap is DeltaSwap {
 
     function getPairFor(address tokenA, address tokenB) public virtual view
         returns(address pair, address token0, address token1) {
-        return pairFor(tokenA, tokenB);
+        return pairFor(tokenA, tokenB, 0);
     }
 
     function getPairReserves(address tokenA, address tokenB) public virtual view

--- a/contracts/test/routes/TestSushiswapV2.sol
+++ b/contracts/test/routes/TestSushiswapV2.sol
@@ -14,7 +14,7 @@ contract TestSushiswapV2 is SushiswapV2 {
 
     function getPairFor(address tokenA, address tokenB) public virtual view
         returns(address pair, address token0, address token1) {
-        return pairFor(tokenA, tokenB);
+        return pairFor(tokenA, tokenB, 0);
     }
 
     function getPairReserves(address tokenA, address tokenB) public virtual view

--- a/contracts/test/routes/TestUniswapV2.sol
+++ b/contracts/test/routes/TestUniswapV2.sol
@@ -14,7 +14,7 @@ contract TestUniswapV2 is UniswapV2 {
 
     function getPairFor(address tokenA, address tokenB) public virtual view
         returns(address pair, address token0, address token1) {
-        return pairFor(tokenA, tokenB);
+        return pairFor(tokenA, tokenB, 0);
     }
 
     function getPairReserves(address tokenA, address tokenB) public virtual view

--- a/contracts/test/routes/TestUniswapV3.sol
+++ b/contracts/test/routes/TestUniswapV3.sol
@@ -15,7 +15,7 @@ contract TestUniswapV3 is UniswapV3 {
 
     function getPairFor(address tokenA, address tokenB, uint24 fee) public virtual view
         returns(address pair) {
-        return pairFor(tokenA, tokenB, fee);
+        (pair,,) = pairFor(tokenA, tokenB, fee);
     }
 
     function getDecodedPrice(uint256 sqrtPriceX96, uint256 decimals) public virtual view

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gammaswap/universal-router",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Universal Router for GammaSwap protocol",
   "homepage": "https://gammaswap.com",
   "scripts": {


### PR DESCRIPTION
-add trackPair function to emit TrackPair event to signal subgraph to track event. Only works for routes set up in UniversalRouter
-make pairFor a public view function in IProtocolRoute
-return factory contract address of AMM in IProtocolRoute