### PR TITLE
Feat: add protocolId to event emitted by UniversalRouter

### DIFF
--- a/contracts/UniversalRouter.sol
+++ b/contracts/UniversalRouter.sol
@@ -33,7 +33,7 @@ contract UniversalRouter is IUniversalRouter, IRouterExternalCallee, Initializab
     }
 
     /// @dev Initialize UniversalRouter when used as a proxy contract
-    function initialize() public virtual initializer {
+    function initialize() public virtual override initializer {
         require(owner() == address(0), "UniversalRouter: INITIALIZED");
         _transferOwnership(msg.sender);
     }
@@ -255,7 +255,7 @@ contract UniversalRouter is IUniversalRouter, IRouterExternalCallee, Initializab
 
         trackedPairs[pair] = block.timestamp;
 
-        emit TrackPair(pair, token0, token1, fee, factory);
+        emit TrackPair(pair, token0, token1, fee, factory, protocolId);
     }
 
     /// @inheritdoc IUniversalRouter
@@ -266,7 +266,7 @@ contract UniversalRouter is IUniversalRouter, IRouterExternalCallee, Initializab
 
         trackedPairs[pair] = 0;
 
-        emit UnTrackPair(pair, token0, token1, fee, factory);
+        emit UnTrackPair(pair, token0, token1, fee, factory, protocolId);
     }
 
     /// @inheritdoc IUniversalRouter

--- a/contracts/interfaces/IUniversalRouter.sol
+++ b/contracts/interfaces/IUniversalRouter.sol
@@ -11,9 +11,9 @@ interface IUniversalRouter {
     /// @dev emitted when a protocol route is removed
     event RemoveProtocolRoute(uint16 indexed protocolId, address protocol);
     /// @dev emitted when a pair is tracked
-    event TrackPair(address indexed pair, address token0, address token1, uint24 fee, address factory);
+    event TrackPair(address indexed pair, address token0, address token1, uint24 fee, address factory, uint16 protocolId);
     /// @dev emitted when a pair is un-tracked
-    event UnTrackPair(address indexed pair, address token0, address token1, uint24 fee, address factory);
+    event UnTrackPair(address indexed pair, address token0, address token1, uint24 fee, address factory, uint16 protocolId);
 
     /// @dev Route struct that contains instructions to perform a swap through supported routes
     struct Route {
@@ -34,6 +34,9 @@ interface IUniversalRouter {
         /// @dev address of IProtocolRoute contract for each AMM swap
         address hop;
     }
+
+    /// @dev function to initialize contract storage variables
+    function initialize() external;
 
     /// @dev Get protocol route identified by protocolId from supported routes
     /// @param protocolId - protocolId identifying route to retrieve

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gammaswap/universal-router",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Universal Router for GammaSwap protocol",
   "homepage": "https://gammaswap.com",
   "scripts": {

--- a/test/foundry/UniversalRouterTest.t.sol
+++ b/test/foundry/UniversalRouterTest.t.sol
@@ -40,8 +40,8 @@ contract UniversalRouterTest is TestBed {
         uint256 amountOut
     );
 
-    event TrackPair(address indexed pair, address token0, address token1, uint24 fee, address factory);
-    event UnTrackPair(address indexed pair, address token0, address token1, uint24 fee, address factory);
+    event TrackPair(address indexed pair, address token0, address token1, uint24 fee, address factory, uint16 protocolId);
+    event UnTrackPair(address indexed pair, address token0, address token1, uint24 fee, address factory, uint16 protocolId);
 
     function setUp() public {
         random = new Random();
@@ -762,13 +762,13 @@ contract UniversalRouterTest is TestBed {
             router.trackPair(token0, token1, _poolFee, protocolId);
 
             vm.expectEmit();
-            emit TrackPair(pair, _token0, _token1, _poolFee, _factory);
+            emit TrackPair(pair, _token0, _token1, _poolFee, _factory, protocolId);
             router.trackPair(token0, token1, _poolFee, protocolId);
 
             assertEq(router.trackedPairs(pair), block.timestamp);
 
             vm.expectEmit();
-            emit TrackPair(pair, _token0, _token1, _poolFee, _factory);
+            emit TrackPair(pair, _token0, _token1, _poolFee, _factory, protocolId);
             router.trackPair(token0, token1, _poolFee, protocolId);
 
             assertEq(router.trackedPairs(pair), block.timestamp);
@@ -788,13 +788,13 @@ contract UniversalRouterTest is TestBed {
             router.unTrackPair(token0, token1, _poolFee, protocolId);
 
             vm.expectEmit();
-            emit UnTrackPair(pair, _token0, _token1, _poolFee, _factory);
+            emit UnTrackPair(pair, _token0, _token1, _poolFee, _factory, protocolId);
             router.unTrackPair(token0, token1, _poolFee, protocolId);
 
             assertEq(router.trackedPairs(pair), 0);
 
             vm.expectEmit();
-            emit UnTrackPair(pair, _token0, _token1, _poolFee, _factory);
+            emit UnTrackPair(pair, _token0, _token1, _poolFee, _factory, protocolId);
             router.unTrackPair(token0, token1, _poolFee, protocolId);
 
             assertEq(router.trackedPairs(pair), 0);
@@ -817,13 +817,13 @@ contract UniversalRouterTest is TestBed {
             router.trackPair(token0, token1, _poolFee, protocolId);
 
             vm.expectEmit();
-            emit TrackPair(pair, _token0, _token1, _poolFee, _factory);
+            emit TrackPair(pair, _token0, _token1, _poolFee, _factory, protocolId);
             router.trackPair(token0, token1, _poolFee, protocolId);
 
             assertEq(router.trackedPairs(pair), block.timestamp);
 
             vm.expectEmit();
-            emit TrackPair(pair, _token0, _token1, _poolFee, _factory);
+            emit TrackPair(pair, _token0, _token1, _poolFee, _factory, protocolId);
             router.trackPair(token0, token1, _poolFee, protocolId);
 
             assertEq(router.trackedPairs(pair), block.timestamp);
@@ -843,13 +843,13 @@ contract UniversalRouterTest is TestBed {
             router.unTrackPair(token0, token1, _poolFee, protocolId);
 
             vm.expectEmit();
-            emit UnTrackPair(pair, _token0, _token1, _poolFee, _factory);
+            emit UnTrackPair(pair, _token0, _token1, _poolFee, _factory, protocolId);
             router.unTrackPair(token0, token1, _poolFee, protocolId);
 
             assertEq(router.trackedPairs(pair), 0);
 
             vm.expectEmit();
-            emit UnTrackPair(pair, _token0, _token1, _poolFee, _factory);
+            emit UnTrackPair(pair, _token0, _token1, _poolFee, _factory, protocolId);
             router.unTrackPair(token0, token1, _poolFee, protocolId);
 
             assertEq(router.trackedPairs(pair), 0);


### PR DESCRIPTION
-add protocolId to TrackPair and unTrackPair events
-make initialize part of the IUniversalRouter interface